### PR TITLE
fixed TypeError in token estimation when message value is None

### DIFF
--- a/review_worker/aries/util/gpt3.py
+++ b/review_worker/aries/util/gpt3.py
@@ -68,6 +68,10 @@ class Gpt3CacheClient:
         for message in messages:
             num_tokens += tokens_per_message
             for key, value in message.items():
+                if value is None:
+                    value = ""
+                elif not isinstance(value, str):
+                    value = str(value)
                 num_tokens += len(tokenizer.encode(value))
                 if key == "name":
                     num_tokens += tokens_per_name


### PR DESCRIPTION

Handle non-string values in estimate_messages_num_tokens() to prevent
TypeError when tiktoken attempts to encode None or non-string values.

Previously, the tokenizer would crash with "TypeError: expected string
or buffer" if any message field contained None or a non-string type.
This could occur when message construction encounters missing fields or
unexpected data types during paper parsing.

The fix converts None to empty string and coerces other non-string
types to strings before tokenization, allowing graceful handling of
edge cases while maintaining accurate token counting.

Fixes issue where review generation fails with TypeError during token
estimation for certain papers.